### PR TITLE
Adicionado Suporte para o Novo formato de CNPJ

### DIFF
--- a/src/cnpj.ts
+++ b/src/cnpj.ts
@@ -13,12 +13,12 @@ const BLACKLIST: Array<string> = [
 ]
 
 const STRICT_STRIP_REGEX: RegExp = /[-\\/.]/g
-const LOOSE_STRIP_REGEX: RegExp = /[^\d]/g
+const LOOSE_STRIP_REGEX: RegExp = /[^(\d)A-Z]/g
 
 const verifierDigit = (digits: string): number => {
   let index: number = 2
   const reverse: Array<number> = digits.split('').reduce((buffer, number) => {
-    return [parseInt(number, 10)].concat(buffer)
+    return [number.charCodeAt(0) - 48].concat(buffer)
   }, [])
 
   const sum: number = reverse.reduce((buffer, number) => {
@@ -37,7 +37,7 @@ const strip = (number: string, strict?: boolean): string => {
 }
 
 const format = (number: string): string => {
-  return strip(number).replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/, '$1.$2.$3/$4-$5')
+  return strip(number).replace(/^([\dA-Z]{2})([\dA-Z]{3})([\dA-Z]{3})([\dA-Z]{4})(\d{2})$/, '$1.$2.$3/$4-$5')
 }
 
 const isValid = (number: string, strict?: boolean): boolean => {
@@ -68,8 +68,9 @@ const isValid = (number: string, strict?: boolean): boolean => {
 const generate = (formatted?: boolean): string => {
   let numbers: string = ''
 
+  const validChars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
   for (let i = 0; i < 12; i += 1) {
-    numbers += Math.floor(Math.random() * 9)
+    numbers += validChars[Math.floor(Math.random() * validChars.length)]
   }
 
   numbers += verifierDigit(numbers)

--- a/src/cnpj.ts
+++ b/src/cnpj.ts
@@ -13,7 +13,7 @@ const BLACKLIST: Array<string> = [
 ]
 
 const STRICT_STRIP_REGEX: RegExp = /[-\\/.]/g
-const LOOSE_STRIP_REGEX: RegExp = /[^(\d)A-Z]/g
+const LOOSE_STRIP_REGEX: RegExp = /[^\dA-Z]/g
 
 const verifierDigit = (digits: string): number => {
   let index: number = 2

--- a/test/cnpj.test.ts
+++ b/test/cnpj.test.ts
@@ -53,14 +53,14 @@ describe('CNPJ', () => {
   test ('gera número formatado', () => {
     var number = cnpj.generate(true)
 
-    expect(number).toMatch(/^(\d{2}).(\d{3}).(\d{3})\/(\d{4})-(\d{2})$/)
+    expect(number).toMatch(/^([\dA-Z]{2}).([\dA-Z]{3}).([\dA-Z]{3})\/([\dA-Z]{4})-(\d{2})$/)
     expect(cnpj.isValid(number)).toBeTruthy()
   })
 
   test ('gera número não formatado', () => {
     var number = cnpj.generate()
 
-    expect(number).toMatch(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/)
+    expect(number).toMatch(/^([\dA-Z]{2})([\dA-Z]{3})([\dA-Z]{3})([\dA-Z]{4})(\d{2})$/)
     expect(cnpj.isValid(number)).toBeTruthy()
   })
 })


### PR DESCRIPTION
A partir de 2026, a Receita Federal implementará uma nova estrutura para o Cadastro Nacional de Pessoas Jurídicas (CNPJ), introduzindo um formato alfanumérico conforme a [Nota Técnica nº conjunta COCAD/SUARA/RFB nº 49/2024](http://sadd.receita.fazenda.gov.br/sadd-internet/pages/validadocumento.xhtml).

Este Pull Request implementa um suporte a esta nova estrutura.

- Alterada geração do código verificador para usar a nova regra
- Alterada função `strip` para não remover letras maiúsculas quando `strict = false`
- Alterada função `generate` para gerar CNPJs no novo formato
- Alteração nos testes de geração de CNPJ, todos os outros testes não foram alterados

Não adicionei opções para usar o formato somente numérico, mas posso adicionar caso necessário.

Acredito que a mesclagem deverá ser feita somente mais perto de 2026, ou em uma versão Maior (2.0.0), pois altera a biblioteca de forma que não mantém compatibilidade com versões anteriores