### PR TITLE
fix(cpf,cnpj): strict mode rejeita máscara malformada (fecha #51)

### DIFF
--- a/.changeset/fix-strict-mode-mask.md
+++ b/.changeset/fix-strict-mode-mask.md
@@ -1,0 +1,16 @@
+---
+'cpf-cnpj-validator': patch
+---
+
+fix(cpf,cnpj): strict mode agora rejeita máscara malformada
+
+`cpf.isValid` e `cnpj.isValid` em modo strict passam a validar o shape canônico antes de stripar a máscara. Entradas com pontos, barras ou hífens duplicados/em posição errada (ex: `'12......ABC.345/01DE-35'`) agora retornam `false` mesmo quando o cálculo do DV após o strip conferiria.
+
+Aceitos em strict:
+
+- Máscara canônica RFB: `XXX.XXX.XXX-XX` (CPF) e `XX.XXX.XXX/XXXX-YY` (CNPJ)
+- 11 dígitos crus (CPF) ou 14 caracteres `[0-9A-Z]{12}\d{2}` (CNPJ)
+
+Modo loose (`strict` omitido ou `false`) permanece inalterado. Comportamento de `strip` em strict também permanece inalterado — apenas `isValid` ganhou a validação prévia do shape.
+
+Fecha [#51](https://github.com/carvalhoviniciusluiz/cpf-cnpj-validator/issues/51).

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ E a todos que abriram issues reportando bugs ou pedindo features — cada contri
 
 Se essa lib te economizou tempo em validação de CPF/CNPJ, considere apoiar o desenvolvimento:
 
-<a href="https://www.buymeacoffee.com/carvalhotech" target="_blank">
+<a href="https://buymeacoffee.com/viniciusluiz" target="_blank">
   <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy me a coffee" height="40">
 </a>
 

--- a/src/cnpj.ts
+++ b/src/cnpj.ts
@@ -15,6 +15,8 @@ const BLACKLIST = new Set<string>([
 
 const STRICT_STRIP_REGEX = /[./-]/g
 const LOOSE_STRIP_REGEX = /[^\dA-Z]/g
+const STRICT_MASK_REGEX =
+  /^(?:[\dA-Z]{2}\.[\dA-Z]{3}\.[\dA-Z]{3}\/[\dA-Z]{4}-\d{2}|[\dA-Z]{12}\d{2})$/
 const VALID_CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 /** Opções para `cnpj.generate()`. */
@@ -78,6 +80,9 @@ function format(value: string): string {
  * ```
  */
 function isValid(value: string, strict?: boolean): boolean {
+  if (strict && (typeof value !== 'string' || !STRICT_MASK_REGEX.test(value))) {
+    return false
+  }
   const stripped = strip(value, strict)
   if (!stripped || stripped.length !== 14 || BLACKLIST.has(stripped)) {
     return false

--- a/src/cpf.ts
+++ b/src/cpf.ts
@@ -16,6 +16,7 @@ const BLACKLIST = new Set<string>([
 
 const STRICT_STRIP_REGEX = /[.-]/g
 const LOOSE_STRIP_REGEX = /[^\d]/g
+const STRICT_MASK_REGEX = /^(?:\d{3}\.\d{3}\.\d{3}-\d{2}|\d{11})$/
 
 /**
  * Mapa dos 27 UFs brasileiros para seus dígitos de Região Fiscal da
@@ -110,6 +111,9 @@ function format(value: string): string {
  * ```
  */
 function isValid(value: string, strict?: boolean): boolean {
+  if (strict && (typeof value !== 'string' || !STRICT_MASK_REGEX.test(value))) {
+    return false
+  }
   const stripped = strip(value, strict)
   if (!stripped || stripped.length !== 11 || BLACKLIST.has(stripped)) {
     return false

--- a/test/cnpj.test.ts
+++ b/test/cnpj.test.ts
@@ -149,6 +149,31 @@ describe('CNPJ', () => {
   })
 
   /**
+   * SPECIFICATION: Em modo strict, isValid deve aceitar apenas a máscara
+   *                canônica da RFB (XX.XXX.XXX/XXXX-YY) ou 14 caracteres
+   *                crus [0-9A-Z]{12}\d{2}. Caracteres de máscara em
+   *                quantidade ou posição diferentes do canônico quebram
+   *                o shape e devem reprovar a entrada.
+   * BEHAVIOR: cnpj.isValid('12......ABC.345/01DE-35', true) retorna
+   *           false; o mesmo para hífens/barras duplicados ou em
+   *           posição errada.
+   * INTENT: Fechar issue #51 — antes da correção, o strip do strict
+   *         removia /[./-]/g em qualquer quantidade, permitindo que
+   *         entradas malformadas passassem desde que o DV resultante
+   *         conferisse. Strict agora valida o shape ANTES do strip.
+   * FLOW: isValid(value, true) → STRICT_MASK_REGEX.test(value) → false
+   *       antes mesmo de stripar e calcular DV.
+   * @covers src/cnpj.ts isValid (validação de shape em strict)
+   * @see https://github.com/carvalhoviniciusluiz/cpf-cnpj-validator/issues/51
+   */
+  test('rejeita CNPJ em strict com caracteres de máscara duplicados', () => {
+    expect(cnpj.isValid('12......ABC.345/01DE-35', true)).toBeFalsy()
+    expect(cnpj.isValid('12.A-----BC.345/01DE-35', true)).toBeFalsy()
+    expect(cnpj.isValid('54.550.752/////0001-55', true)).toBeFalsy()
+    expect(cnpj.isValid('54.550.752/0001---55', true)).toBeFalsy()
+  })
+
+  /**
    * SPECIFICATION: Pergunta 2 do PDF oficial — "DV: Dígito Verificador
    *                utilizando o cálculo pelo módulo 11". O DV resultante
    *                do mod 11 é sempre 0..9 (numérico), pela definição

--- a/test/cpf.test.ts
+++ b/test/cpf.test.ts
@@ -41,6 +41,27 @@ describe('CPF', () => {
     expect(cpf.isValid('29537995593', true)).toBeTruthy()
   })
 
+  /**
+   * SPECIFICATION: Em modo strict, isValid deve aceitar apenas a máscara
+   *                canônica (XXX.XXX.XXX-XX) ou 11 dígitos crus. Pontos
+   *                e hífens duplicados ou em posição errada quebram o
+   *                shape e devem reprovar a entrada.
+   * BEHAVIOR: cpf.isValid('295......379.955-93', true) retorna false;
+   *           idem para hífens duplicados.
+   * INTENT: Mesma classe de bug do CNPJ (issue #51). O strict do CPF
+   *         removia /[.-]/g em qualquer quantidade, permitindo que
+   *         entradas malformadas passassem desde que o DV final
+   *         conferisse. Corrigido em conjunto com o CNPJ para manter
+   *         consistência semântica entre os dois.
+   * @covers src/cpf.ts isValid (validação de shape em strict)
+   * @see https://github.com/carvalhoviniciusluiz/cpf-cnpj-validator/issues/51
+   */
+  test('rejeita CPF em strict com caracteres de máscara duplicados', () => {
+    expect(cpf.isValid('295......379.955-93', true)).toBeFalsy()
+    expect(cpf.isValid('295.379.955--93', true)).toBeFalsy()
+    expect(cpf.isValid('295..379..955-93', true)).toBeFalsy()
+  })
+
   test('retorna o número não formatado', () => {
     expect(cpf.strip('295.379.955-93')).toEqual('29537995593')
   })


### PR DESCRIPTION
## Resumo

Fecha [#51](https://github.com/carvalhoviniciusluiz/cpf-cnpj-validator/issues/51) — em strict mode, `isValid` aceitava CNPJs (e CPFs) com pontos/barras/hífens duplicados ou em posição errada, porque o strip removia `/[./-]/g` em qualquer quantidade antes da validação do DV.

## O fix

Em strict, `isValid` agora valida o shape canônico **antes** de stripar:

- **CPF**: `XXX.XXX.XXX-XX` ou 11 dígitos crus
- **CNPJ**: `XX.XXX.XXX/XXXX-YY` ou 14 caracteres `[0-9A-Z]{12}\d{2}`

`strip` e modo loose permanecem inalterados.

## Antes vs depois

```ts
// Antes
cnpj.isValid('12......ABC.345/01DE-35', true) // true ❌
cnpj.isValid('12.A-----BC.345/01DE-35', true) // true ❌

// Depois
cnpj.isValid('12......ABC.345/01DE-35', true) // false ✓
cnpj.isValid('12.A-----BC.345/01DE-35', true) // false ✓
cnpj.isValid('12.ABC.345/01DE-35', true)      // true ✓ (canônico)
cnpj.isValid('12ABC34501DE35', true)          // true ✓ (raw)
```

Bug equivalente em CPF também corrigido por consistência.

## Bonus

Atualiza a URL do Buy Me a Coffee no README.

## Test plan

- [x] 2 novos testes tier (CPF + CNPJ) com docblock SPECIFICATION/BEHAVIOR/INTENT/FLOW
- [x] 100 testes passando (era 98 + 2 novos)
- [x] 100% coverage mantido (branches 86/86)
- [x] `npm run lint` ok
- [x] `npm run typecheck` ok
- [x] Testes existentes não tocados — TDD: RED → GREEN